### PR TITLE
fix: unrecognized arguments error with virtualenv_command

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -24,6 +24,7 @@ build_ignore:
   - ansible.cfg
   - bootstrap*.yml
   - galaxy.yml
+  - issue*.yml
   - ruff.toml
   - tox.ini
   - uv_install.sh

--- a/issue10.yml
+++ b/issue10.yml
@@ -1,0 +1,19 @@
+- name: Issue 10 test
+  hosts: localhost
+  gather_facts: false
+  vars:
+    temp_dir: "{{ lookup('env', 'TMPDIR') | default('/tmp') | normpath }}"
+    work_dir: "{{ temp_dir }}/moreati.uv.pip"
+    test_projects:
+      - sampleproject
+  tasks:
+    - name: Create work dir
+      file:
+        path: "{{ work_dir }}"
+        state: directory
+        mode: u=rwx,go=rx
+
+    - moreati.uv.pip:
+        name: "{{ test_projects }}"
+        virtualenv: "{{ work_dir }}/issue10"
+        #virtualenv_command: "{{ ansible_playbook_python }} -mvenv"

--- a/plugins/modules/pip.py
+++ b/plugins/modules/pip.py
@@ -283,6 +283,18 @@ def _is_vcs_url(name):
     return re.match(_VCS_RE, name)
 
 
+def _is_venv_command(command):
+    venv_parser = argparse.ArgumentParser()
+    venv_parser.add_argument('-m', type=str)
+    argv = shlex.split(command)
+    if argv[0] == 'pyvenv':
+        return True
+    args, dummy = venv_parser.parse_known_args(argv[1:])
+    if args.m == 'venv':
+        return True
+    return False
+
+
 def _is_package_name(name):
     """Test whether the name is a package name or a version specifier."""
     return not name.lstrip().startswith(tuple(op_dict.keys()))
@@ -416,10 +428,24 @@ def setup_virtualenv(module, env, chdir, out, err):
     cmd.extend(['--python-preference', 'only-system'])
 
     virtualenv_python = module.params['virtualenv_python']
-    if virtualenv_python:
-        cmd.extend(['--python', virtualenv_python])
-    else:
-        cmd.extend(['--python', sys.executable])
+    # -p is a virtualenv option, not compatible with pyenv or venv
+    # this conditional validates if the command being used is not any of them
+    if not _is_venv_command(module.params['virtualenv_command']):
+        if virtualenv_python:
+            cmd.append('-p%s' % virtualenv_python)
+        else:
+            # This code mimics the upstream behaviour of using the python
+            # which invoked virtualenv to determine which python is used
+            # inside of the virtualenv (when none are specified).
+            cmd.append('-p%s' % sys.executable)
+
+    # if venv or pyvenv are used and virtualenv_python is defined, then
+    # virtualenv_python is ignored, this has to be acknowledged
+    elif module.params['virtualenv_python']:
+        module.fail_json(
+            msg='virtualenv_python should not be used when'
+                ' using the venv module or pyvenv as virtualenv_command'
+        )
 
     cmd.append(env)
     rc, out_venv, err_venv = module.run_command(cmd, cwd=chdir)


### PR DESCRIPTION
If `virtualenv_command` is specified, then it may invoke the stdlib `venv` module, which doesn't support `-p` or `--python`. This reverts an earlier deletion of code from `ansible.builtin.pip` that handles this case.

Only `uv venv` accepts `--python-preference`. If `virtualenv_command` is specified then it may invoke `virtualenv`, `python -mvenv`, `pyenv`, ...

fixes #10